### PR TITLE
Fix invalid grade category when switching courses

### DIFF
--- a/src/routes/(authed)/grades/[index]/AssignmentTabs.svelte
+++ b/src/routes/(authed)/grades/[index]/AssignmentTabs.svelte
@@ -36,9 +36,17 @@
 	const categoryDropdownOptions = $derived(
 		gradeCategories ? new Set(gradeCategories.map((category) => category.name)) : undefined
 	);
+
+	let selectedCategory: string = $state('all');
+
+	$effect(() => {
+		if (!gradeCategories?.map((value) => value.name).includes(selectedCategory)) {
+			selectedCategory = 'all';
+		}
+	});
 </script>
 
-<Tabs.Root value="all" class="mx-4 gap-4">
+<Tabs.Root bind:value={selectedCategory} class="mx-4 gap-4">
 	<Tabs.List class="mx-auto h-12 max-w-full justify-start overflow-x-auto">
 		<Tabs.Trigger value="all">All</Tabs.Trigger>
 


### PR DESCRIPTION
If you switch courses while you have a grade category selected, that grade category doesn't update and if the new course doesn't have a category under the same name (which is very likely) then an invalid tab is selected no assignments are shown. This PR fixes that by ensuring any category selection is valid when the course or category selection updates and defaults to "all" if invalid.