### PR TITLE
feat: on-device PXP2 companion extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ Thumbs.db
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# Extension build
+extension/dist
+
 # Mocked data
 src/lib/mocks/data

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 An advanced grade calculator.
 
-> [!WARNING]
-> GradeCompass is now obsolete. It is not compatible with the new API and cannot be updated to support it.
+> [!NOTE]
+> Direct website login no longer works. StudentVUE's SOAP API was shut off (error D5518-00). The new protocol is cookie-session based and will not send credentials to a third-party site. GradeCompass stays on-device by using a **companion browser extension** as a local bridge: you log in on the official portal, and the extension reads gradebook data with your browser cookies.
 
 ## Developing
 
@@ -15,6 +15,18 @@ Make sure to have [Bun](https://bun.sh) installed, then run `bun install` to ins
 bun run dev
 ```
 
+### Companion extension
+
+```bash
+bun run extension:build
+```
+
+Then in Chrome open `chrome://extensions`, enable Developer mode, and Load unpacked → `extension/dist`.
+
+Keep the extension loaded while using `bun run dev` at `http://gradecompass.localhost:5173`. On the login page, enter your district host (for example `ca-xxxx-psv.edupoint.com`) and choose **Continue to StudentVUE**. After you sign in on the official portal, GradeCompass loads grades locally.
+
+The extension only talks to GradeCompass origins and to the district host you grant. It is not a generic CORS proxy.
+
 ### Building
 
 ```bash
@@ -23,8 +35,12 @@ bun run build
 
 You can preview the production build with `bun run preview`.
 
+```bash
+bun test
+```
+
 ## Hosting
 
 When hosting your own version of GradeCompass, please [change](src/lib/brand.ts) the name, icon, contact email, and repository link to avoid confusion with our version.
 
-Vercel and Netlify are both good options for hosting SvelteKit apps like GradeCompass.
+Vercel and Netlify are both good options for hosting SvelteKit apps like GradeCompass. Users still need the companion extension for a live StudentVUE login; the hosted site never sees passwords or grades.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,9 @@ const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
 
 export default tseslint.config(
 	includeIgnoreFile(gitignorePath),
+	{
+		ignores: ['extension/dist/**', 'extension/vite.config.ts', 'extension/content.js']
+	},
 	eslint.configs.recommended,
 	...tseslint.configs.recommendedTypeChecked,
 	...svelte.configs['flat/recommended'],

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,5 @@
+# GradeCompass Companion
+
+Unpacked Chrome MV3 extension. Build with `bun run extension:build` from the repo root, then load `extension/dist` at `chrome://extensions`.
+
+The background worker is the only process that fetches StudentVUE. The content script only relays messages from GradeCompass pages.

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,21 @@
+const PAGE_SOURCE = 'gradecompass-page';
+const BRIDGE_SOURCE = 'gradecompass-bridge';
+
+window.addEventListener('message', (event) => {
+	if (event.source !== window) return;
+	const data = event.data;
+	if (!data || data.source !== PAGE_SOURCE || typeof data.id !== 'number') return;
+
+	const id = data.id;
+	chrome.runtime.sendMessage(data.payload, (response) => {
+		const error = chrome.runtime.lastError;
+		window.postMessage(
+			{
+				source: BRIDGE_SOURCE,
+				id,
+				response: error ? { ok: false, error: error.message } : response
+			},
+			'*'
+		);
+	});
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,30 @@
+{
+	"manifest_version": 3,
+	"name": "GradeCompass Companion",
+	"version": "0.1.0",
+	"description": "Lets GradeCompass read your StudentVUE gradebook on-device after you log in on the official portal.",
+	"background": {
+		"service_worker": "background.js",
+		"type": "module"
+	},
+	"content_scripts": [
+		{
+			"matches": [
+				"https://gradecompass.org/*",
+				"https://*.gradecompass.org/*",
+				"http://gradecompass.localhost/*",
+				"http://gradecompass.localhost:*/*",
+				"https://gradecompass.localhost/*",
+				"https://gradecompass.localhost:*/*",
+				"http://localhost/*",
+				"http://localhost:*/*",
+				"http://127.0.0.1/*",
+				"http://127.0.0.1:*/*"
+			],
+			"js": ["content.js"],
+			"run_at": "document_start"
+		}
+	],
+	"permissions": ["tabs"],
+	"optional_host_permissions": ["https://*/*", "http://*/*"]
+}

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,0 +1,119 @@
+import {
+	districtOrigin,
+	fetchPxp2Gradebook,
+	fetchStudent,
+	hasPxp2Session,
+	normalizeDomain,
+	type Pxp2Transport
+} from '../../src/lib/pxp2';
+import type { BridgeRequest, BridgeResponse, Pxp2StudentInfo } from '../../src/lib/pxp2/protocol';
+
+const TRUSTED_HOSTS = new Set([
+	'gradecompass.org',
+	'gradecompass.localhost',
+	'localhost',
+	'127.0.0.1'
+]);
+
+function isTrustedSender(sender: { url?: string; tab?: { url?: string } }): boolean {
+	const raw = sender.tab?.url ?? sender.url;
+	if (raw === undefined || raw.length === 0) return false;
+
+	try {
+		const url = new URL(raw);
+		return TRUSTED_HOSTS.has(url.hostname) || url.hostname.endsWith('.gradecompass.org');
+	} catch {
+		return false;
+	}
+}
+
+function transportFor(domain: string): Pxp2Transport {
+	return {
+		origin: districtOrigin(domain),
+		fetch: globalThis.fetch.bind(globalThis)
+	};
+}
+
+async function ensureHostPermission(domain: string): Promise<void> {
+	const origin = `${districtOrigin(domain)}/*`;
+	const already = await chrome.permissions.contains({ origins: [origin] });
+	if (already) return;
+
+	const granted = await chrome.permissions.request({ origins: [origin] });
+	if (!granted) {
+		throw new Error('Permission to access your district portal was denied');
+	}
+}
+
+async function waitForSession(domain: string, timeoutMs = 5 * 60 * 1000): Promise<Pxp2StudentInfo> {
+	const transport = transportFor(domain);
+	const started = Date.now();
+
+	while (Date.now() - started < timeoutMs) {
+		const student = await hasPxp2Session(transport);
+		if (student !== undefined) return student;
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	}
+
+	throw new Error('Timed out waiting for a StudentVUE login');
+}
+
+async function beginLogin(domain: string): Promise<Pxp2StudentInfo> {
+	await ensureHostPermission(domain);
+	const existing = await hasPxp2Session(transportFor(domain));
+	if (existing !== undefined) return existing;
+
+	await chrome.tabs.create({
+		url: `${districtOrigin(domain)}/PXP2_Login_Student.aspx?regenerateSessionId=True`,
+		active: true
+	});
+
+	return waitForSession(domain);
+}
+
+async function handle(message: BridgeRequest): Promise<unknown> {
+	switch (message.type) {
+		case 'ping':
+			return true;
+		case 'hasSession': {
+			const domain = normalizeDomain(message.domain);
+			const origin = `${districtOrigin(domain)}/*`;
+			const allowed = await chrome.permissions.contains({ origins: [origin] });
+			if (!allowed) return { loggedIn: false };
+			const student = await hasPxp2Session(transportFor(domain));
+			return { loggedIn: student !== undefined, student };
+		}
+		case 'beginLogin': {
+			const domain = normalizeDomain(message.domain);
+			return beginLogin(domain);
+		}
+		case 'gradebook': {
+			const domain = normalizeDomain(message.domain);
+			await ensureHostPermission(domain);
+			return fetchPxp2Gradebook(transportFor(domain), message.reportPeriod);
+		}
+		case 'studentInfo': {
+			const domain = normalizeDomain(message.domain);
+			await ensureHostPermission(domain);
+			return fetchStudent(transportFor(domain));
+		}
+		default:
+			throw new Error('Unknown companion extension request');
+	}
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+	if (!isTrustedSender(sender)) {
+		sendResponse({ ok: false, error: 'Untrusted sender' } satisfies BridgeResponse);
+		return false;
+	}
+
+	void handle(message as BridgeRequest)
+		.then((data) => sendResponse({ ok: true, data } satisfies BridgeResponse))
+		.catch((error: unknown) => {
+			const text = error instanceof Error ? error.message : String(error);
+			sendResponse({ ok: false, error: text } satisfies BridgeResponse);
+		});
+
+	return true;
+});

--- a/extension/src/chrome-env.d.ts
+++ b/extension/src/chrome-env.d.ts
@@ -1,0 +1,26 @@
+export {};
+
+declare global {
+	const chrome: {
+		runtime: {
+			lastError?: { message: string };
+			onMessage: {
+				addListener(
+					callback: (
+						message: unknown,
+						sender: { url?: string; tab?: { url?: string } },
+						sendResponse: (response: unknown) => void
+					) => boolean | void
+				): void;
+			};
+			sendMessage: (message: unknown, responseCallback: (response: unknown) => void) => void;
+		};
+		permissions: {
+			request(permissions: { origins?: string[] }): Promise<boolean>;
+			contains(permissions: { origins?: string[] }): Promise<boolean>;
+		};
+		tabs: {
+			create(createProperties: { url: string; active?: boolean }): Promise<{ id?: number }>;
+		};
+	};
+}

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"lib": ["ES2022", "DOM"],
+		"types": []
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -1,0 +1,39 @@
+import { copyFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const dir = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+	publicDir: false,
+	build: {
+		outDir: resolve(dir, 'dist'),
+		emptyOutDir: true,
+		minify: false,
+		lib: {
+			entry: resolve(dir, 'src/background.ts'),
+			formats: ['es'],
+			fileName: () => 'background.js'
+		},
+		rollupOptions: {
+			output: {
+				inlineDynamicImports: true
+			}
+		}
+	},
+	resolve: {
+		alias: {
+			$lib: resolve(dir, '../src/lib')
+		}
+	},
+	plugins: [
+		{
+			name: 'copy-extension-static',
+			closeBundle() {
+				copyFileSync(resolve(dir, 'manifest.json'), resolve(dir, 'dist/manifest.json'));
+				copyFileSync(resolve(dir, 'content.js'), resolve(dir, 'dist/content.js'));
+			}
+		}
+	]
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
+		"test": "bun test",
+		"extension:build": "vite build --config extension/vite.config.ts",
 		"generate-mocks": "bun run ./generate_mock_data.ts"
 	},
 	"devDependencies": {

--- a/src/lib/account.svelte.ts
+++ b/src/lib/account.svelte.ts
@@ -3,19 +3,27 @@ import { StudentAccount } from '$lib/synergy';
 
 export const acc: { studentAccount?: StudentAccount } = $state({});
 
+interface StoredToken {
+	username?: string;
+	password?: string;
+	domain: string;
+	mode?: 'soap' | 'pxp2';
+}
+
 export const loadStudentAccount = () => {
 	const token = localStorage.getItem(LocalStorageKey.token);
 	if (token === null) return;
 
-	const {
-		username,
-		password,
-		domain
-	}: {
-		username: string;
-		password: string;
-		domain: string;
-	} = JSON.parse(token);
+	const parsed: StoredToken = JSON.parse(token);
 
-	acc.studentAccount = new StudentAccount(domain, username, password);
+	if (parsed.mode === 'pxp2') {
+		acc.studentAccount = StudentAccount.fromPxp2(parsed.domain);
+		return;
+	}
+
+	acc.studentAccount = new StudentAccount(
+		parsed.domain,
+		parsed.username ?? '',
+		parsed.password ?? ''
+	);
 };

--- a/src/lib/bridge.ts
+++ b/src/lib/bridge.ts
@@ -1,0 +1,74 @@
+import {
+	BRIDGE_SOURCE,
+	PAGE_SOURCE,
+	type BridgeRequest,
+	type BridgeResponse
+} from '$lib/pxp2/protocol';
+
+interface Pending {
+	resolve: (value: unknown) => void;
+	reject: (error: Error) => void;
+	timer: number;
+}
+
+const pending = new Map<number, Pending>();
+let requestId = 0;
+let listening = false;
+
+function ensureListener() {
+	if (listening || typeof window === 'undefined') return;
+	listening = true;
+
+	window.addEventListener('message', (event: MessageEvent) => {
+		if (event.source !== window) return;
+		const data = event.data as { source?: string; id?: number; response?: BridgeResponse } | null;
+		if (data?.source !== BRIDGE_SOURCE || typeof data.id !== 'number') return;
+
+		const waiter = pending.get(data.id);
+		if (waiter === undefined) return;
+
+		window.clearTimeout(waiter.timer);
+		pending.delete(data.id);
+
+		const response = data.response;
+		if (response === undefined) {
+			waiter.reject(new Error('Empty response from the companion extension'));
+			return;
+		}
+		if (response.ok) waiter.resolve(response.data);
+		else waiter.reject(new Error(response.error));
+	});
+}
+
+export async function pingBridge(timeoutMs = 400): Promise<boolean> {
+	try {
+		const result = await bridgeRequest({ type: 'ping' }, timeoutMs);
+		return result === true;
+	} catch {
+		return false;
+	}
+}
+
+export async function bridgeRequest<T>(payload: BridgeRequest, timeoutMs = 120000): Promise<T> {
+	if (typeof window === 'undefined') {
+		throw new Error('The companion extension only works in the browser');
+	}
+
+	ensureListener();
+
+	return await new Promise<T>((resolve, reject) => {
+		const id = ++requestId;
+		const timer = window.setTimeout(() => {
+			pending.delete(id);
+			reject(new Error('The GradeCompass companion extension did not respond'));
+		}, timeoutMs);
+
+		pending.set(id, {
+			resolve: (value) => resolve(value as T),
+			reject,
+			timer
+		});
+
+		window.postMessage({ source: PAGE_SOURCE, id, payload }, '*');
+	});
+}

--- a/src/lib/grades/catalog.svelte.ts
+++ b/src/lib/grades/catalog.svelte.ts
@@ -1,12 +1,12 @@
 import { LocalStorageKey } from '$lib';
 import { loadStudentAccount } from '$lib/account.svelte';
-import { parseGradebookXML } from '$lib/synergy';
 import { toast } from 'svelte-sonner';
 import {
 	getGradebookCatalogFromLocalStorage,
 	getGradebookRecord,
 	getInitialGradebookCatalog,
 	gradebookRefreshNeeded,
+	parseGradebookRecord,
 	saveGradebookCatalogToLocalStorage,
 	type GradebookCatalog
 } from './catalog';
@@ -48,7 +48,7 @@ export async function switchReportPeriod({
 		gradebookState.gradebookCatalog.receivingData = false;
 		const gradebookRecord = await getGradebookRecord(onReceivingData, overrideIndex);
 
-		const gradebook = parseGradebookXML(gradebookRecord.xml);
+		const gradebook = parseGradebookRecord(gradebookRecord);
 
 		const receivedIndex = parseInt(gradebook.ReportingPeriod._Index);
 
@@ -121,7 +121,7 @@ export async function initializeGradebookCatalog() {
 		if (seenAssignmentIDs.size === 0) {
 			gradebookState.gradebookCatalog.recordCache
 				.filter((record) => record !== undefined)
-				.flatMap((record) => parseGradebookXML(record.xml).Courses.Course)
+				.flatMap((record) => parseGradebookRecord(record).Courses.Course)
 				.map((course) => course.Marks?.Mark[0]?.Assignments?.Assignment)
 				.filter((assignments) => assignments !== undefined)
 				.flat()

--- a/src/lib/grades/catalog.ts
+++ b/src/lib/grades/catalog.ts
@@ -1,10 +1,11 @@
 import { LocalStorageKey } from '$lib';
 import { acc } from '$lib/account.svelte';
 import { Operation, parseGradebookXML, unwrapEnvelope } from '$lib/synergy';
-import type { ReportPeriod } from '$lib/types/Gradebook';
+import type { Gradebook, ReportPeriod } from '$lib/types/Gradebook';
 
-interface GradebookRecord {
-	xml: string;
+export interface GradebookRecord {
+	xml?: string;
+	gradebook?: Gradebook;
 	lastRefresh: number;
 }
 
@@ -23,16 +24,22 @@ export interface GradebookCatalog {
 	canonicalReportPeriodEntries?: ReportPeriod[];
 }
 
+export function parseGradebookRecord(record: GradebookRecord): Gradebook {
+	if (record.gradebook !== undefined) return record.gradebook;
+	if (record.xml !== undefined && record.xml.length > 0) return parseGradebookXML(record.xml);
+	throw new Error('Gradebook record is empty');
+}
+
 export function getGradebookCatalogFromLocalStorage() {
 	const cacheStr = localStorage.getItem(LocalStorageKey.gradebook);
 	if (cacheStr === null) return undefined;
 
-	const cache: GradebookCatalogLocalStorageCache = JSON.parse(cacheStr);
+	const cache = JSON.parse(cacheStr) as GradebookCatalogLocalStorageCache;
 
 	const defaultRecord = cache.recordCache[cache.defaultIndex];
 
 	const canonicalReportPeriodEntries = defaultRecord
-		? parseGradebookXML(defaultRecord.xml).ReportingPeriods.ReportPeriod
+		? parseGradebookRecord(defaultRecord).ReportingPeriods.ReportPeriod
 		: undefined;
 
 	const gradebookCatalog: GradebookCatalog = {
@@ -58,6 +65,16 @@ export async function getGradebookRecord(onReceivingData?: () => void, reportPer
 	const { studentAccount } = acc;
 	if (!studentAccount) throw new Error('Cannot get gradebook: student account not loaded');
 
+	if (studentAccount.mode === 'pxp2') {
+		onReceivingData?.();
+		const gradebook = await studentAccount.fetchPxp2Gradebook(reportPeriod);
+		const record: GradebookRecord = {
+			gradebook,
+			lastRefresh: Date.now()
+		};
+		return record;
+	}
+
 	const res = await studentAccount.gradebookRequest(reportPeriod);
 
 	onReceivingData?.();
@@ -74,13 +91,13 @@ export async function getGradebookRecord(onReceivingData?: () => void, reportPer
 export async function getInitialGradebookCatalog() {
 	const defaultGradebookRecord = await getGradebookRecord();
 
-	const defaultGradebook = parseGradebookXML(defaultGradebookRecord.xml);
+	const defaultGradebook = parseGradebookRecord(defaultGradebookRecord);
 
 	const canonicalReportPeriodEntries = defaultGradebook.ReportingPeriods.ReportPeriod;
 
-	const reportingPeriods: (undefined | GradebookRecord)[] = Array(
-		canonicalReportPeriodEntries.length
-	).fill(undefined);
+	const reportingPeriods: (undefined | GradebookRecord)[] = Array.from({
+		length: canonicalReportPeriodEntries.length
+	});
 
 	const defaultIndex = parseInt(defaultGradebook.ReportingPeriod._Index);
 

--- a/src/lib/grades/gradebook.ts
+++ b/src/lib/grades/gradebook.ts
@@ -1,5 +1,5 @@
-import { parseGradebookXML } from '$lib/synergy';
 import type { Gradebook } from '$lib/types/Gradebook';
+import { parseGradebookRecord } from './catalog';
 import { gradebookState } from './catalog.svelte';
 
 let parsedGradebook: { index: number; lastRefresh: number; gradebook: Gradebook } | undefined =
@@ -23,7 +23,7 @@ export function getActiveGradebook() {
 	parsedGradebook = {
 		index,
 		lastRefresh: record.lastRefresh,
-		gradebook: parseGradebookXML(record.xml)
+		gradebook: parseGradebookRecord(record)
 	};
 	return parsedGradebook.gradebook;
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -55,7 +55,7 @@ export async function getBlobURLFromBase64String(base64: string) {
 
 export enum LocalStorageKey {
 	token = 'token',
-	gradebook = 'gradebook4',
+	gradebook = 'gradebook5',
 	seenAssignmentIDs = 'seenAssignmentIDs',
 	triedHypotheticalMode = 'triedHypotheticalMode',
 	attendance = 'attendance',

--- a/src/lib/pxp2/client.ts
+++ b/src/lib/pxp2/client.ts
@@ -1,0 +1,304 @@
+import type { Gradebook } from '$lib/types/Gradebook';
+import { mapGradebook } from './mapGradebook';
+import {
+	extractAssignmentNames,
+	extractCourseChrome,
+	extractFocusArgsForCourse,
+	extractGbFocusData
+} from './parse';
+import { assertAllowedStudentVuePath } from './paths';
+import type { Pxp2StudentInfo } from './protocol';
+import type {
+	Pxp2ClassData,
+	Pxp2CourseInput,
+	Pxp2CourseMetadata,
+	Pxp2GbFocusData,
+	Pxp2GradingPeriod,
+	Pxp2MeasureType
+} from './types';
+
+export interface Pxp2Transport {
+	origin: string;
+	fetch: typeof fetch;
+}
+
+const PORTAL_HEADERS = {
+	Current_web_portal: 'StudentVUE'
+};
+
+const CLASS_DATA_BODY = {
+	FriendlyName: 'genericdata.classdata',
+	Method: 'GetClassData',
+	Parameters: '{}'
+};
+
+function asString(value: unknown, fallback = ''): string {
+	return typeof value === 'string' ? value : fallback;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	if (typeof value === 'object' && value !== null) return value as Record<string, unknown>;
+	return undefined;
+}
+
+function unwrapAsmx(body: unknown): unknown {
+	const record = asRecord(body);
+	if (record === undefined || !('d' in record)) return body;
+
+	const inner = record.d;
+	if (typeof inner === 'string') {
+		try {
+			return JSON.parse(inner);
+		} catch {
+			return inner;
+		}
+	}
+	return inner;
+}
+
+async function readBody(res: Response): Promise<unknown> {
+	const text = await res.text();
+	if (text.length === 0) return undefined;
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+}
+
+export async function pxp2Request(
+	transport: Pxp2Transport,
+	path: string,
+	init: RequestInit = {}
+): Promise<Response> {
+	assertAllowedStudentVuePath(path);
+	const url = `${transport.origin}${path}`;
+	const headers = new Headers(init.headers);
+	if (!headers.has('Current_web_portal'))
+		headers.set('Current_web_portal', PORTAL_HEADERS.Current_web_portal);
+
+	const res = await transport.fetch(url, {
+		...init,
+		headers,
+		credentials: 'include'
+	});
+
+	if (!res.ok) {
+		throw new Error(`StudentVUE request failed (${res.status}) for ${path.split('?')[0]}`);
+	}
+
+	return res;
+}
+
+export async function fetchStudent(transport: Pxp2Transport): Promise<Pxp2StudentInfo> {
+	const res = await pxp2Request(
+		transport,
+		'/api/v1/components/pxp/student-picker/StudentPicker/GetStudents',
+		{ method: 'POST' }
+	);
+	const body = await readBody(res);
+	const record = asRecord(body);
+	const list = record?.data;
+	if (!Array.isArray(list) || list.length === 0) {
+		throw new Error('Not logged in to StudentVUE');
+	}
+
+	const student = asRecord(list[0]);
+	if (student === undefined) throw new Error('Not logged in to StudentVUE');
+
+	return {
+		name: asString(student.name ?? student.Name, 'Student'),
+		sisNumber: asString(student.sisNumber ?? student.SisNumber),
+		schoolName: asString(student.schoolName ?? student.SchoolName),
+		schoolPhone: asString(student.schoolPhone ?? student.SchoolPhone),
+		photoUrl: asString(student.photoUrl ?? student.PhotoUrl)
+	};
+}
+
+export async function hasPxp2Session(
+	transport: Pxp2Transport
+): Promise<Pxp2StudentInfo | undefined> {
+	try {
+		return await fetchStudent(transport);
+	} catch {
+		return undefined;
+	}
+}
+
+async function fetchGradebookHtml(transport: Pxp2Transport): Promise<string> {
+	const res = await pxp2Request(transport, '/PXP2_GradeBook.aspx?AGU=0', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+	});
+	return res.text();
+}
+
+async function loadControl(
+	transport: Pxp2Transport,
+	control: string,
+	parameters: Record<string, unknown>
+): Promise<string> {
+	const res = await pxp2Request(transport, '/service/PXP2Communication.asmx/LoadControl', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json; charset=utf-8',
+			Referer: `${transport.origin}/PXP2_GradeBook.aspx?AGU=0`
+		},
+		body: JSON.stringify({ request: { control, parameters } })
+	});
+
+	const unwrapped = asRecord(unwrapAsmx(await readBody(res)));
+	const data = asRecord(unwrapped?.Data) ?? unwrapped;
+	const html = data?.html;
+	if (typeof html !== 'string') throw new Error(`StudentVUE did not return ${control} HTML`);
+	return html;
+}
+
+function gradingPeriodPayload(period: Pxp2GradingPeriod): Record<string, unknown> {
+	return {
+		AGU: 0,
+		GradingPeriodGroup: period.GroupName,
+		OrgYearGU: period.OrgYearGU,
+		gradePeriodGU: period.GU,
+		schoolID: period.schoolID
+	};
+}
+
+async function fetchCourseMetadata(
+	transport: Pxp2Transport,
+	period: Pxp2GradingPeriod
+): Promise<Pxp2CourseMetadata[]> {
+	const markPeriodGU = period.MarkPeriods?.[0]?.GU ?? period.GU;
+	const res = await pxp2Request(
+		transport,
+		'/service/PXP2Communication.asmx/GradebookFocusClassInfo',
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+				Referer: `${transport.origin}/PXP2_GradeBook.aspx?AGU=0`
+			},
+			body: JSON.stringify({
+				request: {
+					gradingPeriodGU: period.GU,
+					AGU: '0',
+					orgYearGU: period.OrgYearGU,
+					schoolID: period.schoolID,
+					markPeriodGU
+				}
+			})
+		}
+	);
+
+	const unwrapped = asRecord(unwrapAsmx(await readBody(res)));
+	const data = asRecord(unwrapped?.Data) ?? unwrapped;
+	const classes = data?.Classes;
+	if (!Array.isArray(classes)) throw new Error('StudentVUE did not return class list');
+
+	return classes.map((entry) => {
+		const row = asRecord(entry) ?? {};
+		return {
+			ID: Number(row.ID),
+			Name: asString(row.Name),
+			TeacherName: asString(row.TeacherName)
+		};
+	});
+}
+
+async function fetchClassData(transport: Pxp2Transport): Promise<Pxp2ClassData> {
+	const res = await pxp2Request(
+		transport,
+		'/api/GB/ClientSideData/Transfer?action=genericdata.classdata-GetClassData',
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json; charset=utf-8',
+				Referer: `${transport.origin}/PXP2_GradeBook.aspx?AGU=0`
+			},
+			body: JSON.stringify(CLASS_DATA_BODY)
+		}
+	);
+
+	const body = await readBody(res);
+	const record = asRecord(body);
+	if (record === undefined) throw new Error('StudentVUE did not return class data');
+
+	const assignments = Array.isArray(record.assignments) ? record.assignments : [];
+	const classGrades = Array.isArray(record.classGrades) ? record.classGrades : [];
+	const measureTypeGrades = Array.isArray(record.measureTypeGrades) ? record.measureTypeGrades : [];
+	const measureTypes = Array.isArray(record.measureTypes) ? record.measureTypes : undefined;
+
+	return {
+		assignments: assignments as Pxp2ClassData['assignments'],
+		classGrades: classGrades as Pxp2ClassData['classGrades'],
+		classId: Number(record.classId ?? 0),
+		className: (record.className as string | number) ?? '',
+		gradingPeriodId:
+			typeof record.gradingPeriodId === 'number' ? record.gradingPeriodId : undefined,
+		measureTypeGrades: measureTypeGrades as Pxp2ClassData['measureTypeGrades'],
+		measureTypes: measureTypes as Pxp2MeasureType[] | undefined
+	};
+}
+
+export async function fetchPxp2Gradebook(
+	transport: Pxp2Transport,
+	reportPeriodIndex?: number
+): Promise<Gradebook> {
+	const html = await fetchGradebookHtml(transport);
+	const focus: Pxp2GbFocusData = extractGbFocusData(html);
+	const periods = focus.GradingPeriods;
+	if (periods.length === 0) throw new Error('No grading periods were found');
+
+	const defaultIndex = periods.findIndex((period) => period.defaultFocus);
+	const activeIndex =
+		reportPeriodIndex !== undefined ? reportPeriodIndex : defaultIndex === -1 ? 0 : defaultIndex;
+	const activePeriod = periods[activeIndex];
+	if (activePeriod === undefined) throw new Error('That grading period is not available');
+
+	let periodHtml = html;
+	if (activeIndex !== (defaultIndex === -1 ? 0 : defaultIndex)) {
+		periodHtml = await loadControl(
+			transport,
+			'Gradebook_SchoolClasses',
+			gradingPeriodPayload(activePeriod)
+		);
+	}
+
+	const coursesMeta = await fetchCourseMetadata(transport, activePeriod);
+	let measureTypes: Pxp2MeasureType[] = [];
+	const courses: Pxp2CourseInput[] = [];
+
+	for (const metadata of coursesMeta) {
+		const chrome = extractCourseChrome(periodHtml, metadata.ID);
+		const focusArgs = extractFocusArgsForCourse(periodHtml, metadata.ID);
+		const classHtml = await loadControl(transport, 'Gradebook_ClassDetails', focusArgs);
+		const assignmentNames = extractAssignmentNames(classHtml);
+		const classData = await fetchClassData(transport);
+		if (classData.measureTypes !== undefined && classData.measureTypes.length > 0) {
+			measureTypes = classData.measureTypes;
+		}
+
+		courses.push({
+			metadata: {
+				...metadata,
+				room: chrome.room,
+				markPreview: chrome.markPreview,
+				scorePreview: chrome.scorePreview
+			},
+			classData,
+			assignmentNames,
+			measureTypes
+		});
+	}
+
+	for (const course of courses) {
+		course.measureTypes = measureTypes;
+	}
+
+	return mapGradebook({
+		periods,
+		activePeriod,
+		activeIndex,
+		courses
+	});
+}

--- a/src/lib/pxp2/domain.ts
+++ b/src/lib/pxp2/domain.ts
@@ -1,0 +1,23 @@
+export function normalizeDomain(input: string): string {
+	const trimmed = input.trim();
+	if (trimmed.length === 0) throw new Error('Enter your district portal domain');
+
+	let host = trimmed;
+	if (trimmed.includes('://')) {
+		host = new URL(trimmed).host;
+	} else {
+		host = trimmed.split('/')[0] ?? trimmed;
+	}
+
+	host = host.replace(/:\d+$/, '');
+
+	if (host.length === 0 || host.includes('..') || !/^[a-zA-Z0-9.-]+$/.test(host)) {
+		throw new Error('Invalid district domain');
+	}
+
+	return host;
+}
+
+export function districtOrigin(domain: string): string {
+	return `https://${normalizeDomain(domain)}`;
+}

--- a/src/lib/pxp2/index.ts
+++ b/src/lib/pxp2/index.ts
@@ -1,0 +1,17 @@
+export {
+	fetchPxp2Gradebook,
+	fetchStudent,
+	hasPxp2Session,
+	pxp2Request,
+	type Pxp2Transport
+} from './client';
+export { districtOrigin, normalizeDomain } from './domain';
+export { mapGradebook } from './mapGradebook';
+export {
+	extractAssignmentNames,
+	extractCourseChrome,
+	extractFocusArgsForCourse,
+	extractGbFocusData
+} from './parse';
+export { assertAllowedStudentVuePath, isAllowedStudentVuePath } from './paths';
+export { BRIDGE_SOURCE, PAGE_SOURCE, type BridgeRequest, type BridgeResponse } from './protocol';

--- a/src/lib/pxp2/mapGradebook.ts
+++ b/src/lib/pxp2/mapGradebook.ts
@@ -1,0 +1,222 @@
+import type {
+	AssignmentEntity,
+	AssignmentGradeCalc,
+	Course,
+	Gradebook,
+	Mark,
+	ReportPeriod
+} from '$lib/types/Gradebook';
+import type {
+	MapGradebookInput,
+	Pxp2Assignment,
+	Pxp2ClassGrade,
+	Pxp2CourseInput,
+	Pxp2MeasureType,
+	Pxp2MeasureTypeGrade
+} from './types';
+
+function asPercent(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return value <= 1.5 ? value * 100 : value;
+}
+
+function formatPercent(value: number): string {
+	const pct = asPercent(value);
+	return `${Number(pct.toFixed(2))}%`;
+}
+
+function letterFromPercentage(percentage: number): string {
+	if (percentage >= 89.5) return 'A';
+	if (percentage >= 79.5) return 'B';
+	if (percentage >= 69.5) return 'C';
+	if (percentage >= 59.5) return 'D';
+	return 'F';
+}
+
+function overallPercentage(classGrade: Pxp2ClassGrade | undefined, scorePreview: string): number {
+	if (classGrade?.totalWeightedPercentage !== undefined) {
+		return asPercent(classGrade.totalWeightedPercentage);
+	}
+	if (classGrade?.percentage !== undefined) {
+		return asPercent(classGrade.percentage);
+	}
+	if (classGrade !== undefined && classGrade.pointsPossible > 0) {
+		return (classGrade.points / classGrade.pointsPossible) * 100;
+	}
+
+	const preview = parseFloat(scorePreview.replace('%', ''));
+	return Number.isFinite(preview) ? preview : 0;
+}
+
+function measureTypeName(measureTypes: Pxp2MeasureType[], id: number, fallback: string): string {
+	return measureTypes.find((type) => type.id === id)?.name ?? fallback;
+}
+
+function mapAssignment(
+	assignment: Pxp2Assignment,
+	assignmentNames: Record<number, string>,
+	measureTypes: Pxp2MeasureType[]
+): AssignmentEntity {
+	const name =
+		assignment.name ??
+		assignmentNames[assignment.gradeBookId] ??
+		`Assignment ${assignment.gradeBookId}`;
+	const category =
+		assignment.category.length > 0
+			? assignment.category
+			: measureTypeName(measureTypes, assignment.measureTypeId, '');
+	const maxScore = assignment.maxScore;
+	const graded = assignment.score !== null && assignment.isForGrading && !assignment.excused;
+	const notesParts: string[] = [];
+	if (!assignment.isForGrading || assignment.excused) notesParts.push('(Not For Grading)');
+	if (assignment.commentCode !== null && assignment.commentCode.length > 0) {
+		notesParts.push(assignment.commentCode);
+	}
+
+	const pointsEarned = assignment.score ?? '';
+	const displayScore = graded ? `${assignment.score} out of ${maxScore}` : 'Not Graded';
+	const points = graded ? `${assignment.score} / ${maxScore}` : `${maxScore} Points Possible`;
+
+	return {
+		Resources: null,
+		Standards: null,
+		_GradebookID: String(assignment.gradeBookId),
+		_Measure: name,
+		_Type: category,
+		_Date: assignment.dueDate,
+		_DueDate: assignment.dueDate,
+		_Score: graded ? (assignment.score ?? undefined) : undefined,
+		_DisplayScore: displayScore,
+		_ScoreCalValue: graded ? (assignment.score ?? undefined) : undefined,
+		_TimeSincePost: '',
+		_TotalSecondsSincePost: '0',
+		_ScoreMaxValue: maxScore,
+		_ScoreType: 'Raw Score',
+		_Points: points,
+		_Point: graded ? pointsEarned : undefined,
+		_PointPossible: graded ? maxScore : maxScore,
+		_Notes: notesParts.join(' ').trim(),
+		_TeacherID: '',
+		_StudentID: String(assignment.studentId),
+		_MeasureDescription: '',
+		_HasDropBox: false,
+		_DropStartDate: assignment.dueDate,
+		_DropEndDate: assignment.dueDate
+	};
+}
+
+function mapCategories(
+	measureTypeGrades: Pxp2MeasureTypeGrade[] | undefined,
+	measureTypes: Pxp2MeasureType[]
+): AssignmentGradeCalc[] | undefined {
+	if (measureTypeGrades === undefined || measureTypeGrades.length === 0) return undefined;
+
+	return measureTypeGrades.map((grade) => {
+		const type = measureTypeName(
+			measureTypes,
+			grade.measureTypeId,
+			`Category ${grade.measureTypeId}`
+		);
+		const weight = asPercent(grade.measureTypeWeight);
+		const categoryPct = grade.pointsPossible > 0 ? (grade.points / grade.pointsPossible) * 100 : 0;
+		const weightedContribution = (categoryPct / 100) * weight;
+
+		return {
+			_Type: type,
+			_Weight: `${weight}%`,
+			_Points: String(grade.points),
+			_PointsPossible: String(grade.pointsPossible),
+			_WeightedPct: formatPercent(weightedContribution),
+			_CalculatedMark:
+				grade.calculatedMark.length > 0
+					? grade.calculatedMark
+					: letterFromPercentage(categoryPct)
+		};
+	});
+}
+
+function mapCourse(input: Pxp2CourseInput, periodIndex: number): Course {
+	const { metadata, classData, assignmentNames, measureTypes } = input;
+	const classGrade = classData.classGrades[0];
+	const percentage = overallPercentage(classGrade, metadata.scorePreview ?? '');
+	const fromClass = classGrade?.calculatedMark;
+	const fromPreview = metadata.markPreview;
+	const letter =
+		fromClass !== undefined && fromClass.length > 0
+			? fromClass
+			: fromPreview !== undefined && fromPreview !== null && fromPreview.length > 0
+				? fromPreview
+				: letterFromPercentage(percentage);
+	const categories = mapCategories(classData.measureTypeGrades, measureTypes);
+	const assignments = classData.assignments.map((assignment) =>
+		mapAssignment(assignment, assignmentNames, measureTypes)
+	);
+
+	const mark: Mark = {
+		StandardViews: null,
+		GradeCalculationSummary:
+			categories !== undefined && categories.length > 0
+				? { AssignmentGradeCalc: categories }
+				: null,
+		Assignments: { Assignment: assignments },
+		AssignmentsSinceLastAccess: null,
+		_MarkName: '',
+		_ShortMarkName: '',
+		_CalculatedScoreString: letter,
+		_CalculatedScoreRaw: percentage.toFixed(1)
+	};
+
+	const courseName = metadata.Name;
+	const courseId = String(metadata.ID);
+
+	return {
+		Marks: { Mark: [mark] },
+		_Period: String(periodIndex + 1),
+		_Title: `${courseName} (${courseId})`,
+		_CourseName: courseName,
+		_CourseID: courseId,
+		_Room: metadata.room ?? '',
+		_Staff: metadata.TeacherName,
+		_StaffEMail: '',
+		_StaffGU: '',
+		_ImageType: 'technical',
+		_HighlightPercentageCutOffForProgressBar: '50',
+		_UsesRichContent: false
+	};
+}
+
+export function mapGradebook(input: MapGradebookInput): Gradebook {
+	const reportingPeriods: ReportPeriod[] = input.periods.map((period, index) => ({
+		_GradePeriod: period.Name,
+		_Index: String(index),
+		_StartDate: '',
+		_EndDate: ''
+	}));
+
+	const active =
+		reportingPeriods[input.activeIndex] ??
+		reportingPeriods.find((period) => period._GradePeriod === input.activePeriod.Name) ??
+		reportingPeriods[0];
+
+	if (active === undefined) {
+		throw new Error('No grading periods were returned');
+	}
+
+	return {
+		ReportingPeriods: { ReportPeriod: reportingPeriods },
+		ReportingPeriod: active,
+		Courses: {
+			Course: input.courses.map((course, index) => mapCourse(course, index))
+		},
+		'_xmlns:xsd': 'http://www.w3.org/2001/XMLSchema',
+		'_xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+		_Type: 'Traditional',
+		_ErrorMessage: '',
+		_HideStandardGraphInd: false,
+		_HideMarksColumnElementary: false,
+		_HidePointsColumnElementary: false,
+		_HidePercentSecondary: false,
+		_DisplayStandardsData: false,
+		_GBStandardsTabDefault: false
+	};
+}

--- a/src/lib/pxp2/parse.ts
+++ b/src/lib/pxp2/parse.ts
@@ -1,0 +1,128 @@
+import type { Pxp2GbFocusData } from './types';
+
+export function decodeHtmlAttr(value: string): string {
+	return value
+		.replace(/&quot;/g, '"')
+		.replace(/&#34;/g, '"')
+		.replace(/&amp;/g, '&')
+		.replace(/&#39;/g, "'")
+		.replace(/&apos;/g, "'")
+		.replace(/&lt;/g, '<')
+		.replace(/&gt;/g, '>');
+}
+
+export function extractGbFocusData(html: string): Pxp2GbFocusData {
+	const marker = 'PXP.GBFocusData = ';
+	const start = html.indexOf(marker);
+	if (start === -1) throw new Error('Could not find grading period data on the gradebook page');
+
+	const rest = html.slice(start + marker.length);
+	const endMatch = rest.match(/;\s*(?:\r?\n|$)/);
+	const raw =
+		endMatch?.index !== undefined ? rest.slice(0, endMatch.index) : rest.trim().replace(/;$/, '');
+
+	const parsed: unknown = JSON.parse(raw);
+	if (typeof parsed !== 'object' || parsed === null || !('GradingPeriods' in parsed)) {
+		throw new Error('Gradebook focus data did not include grading periods');
+	}
+
+	return parsed as Pxp2GbFocusData;
+}
+
+export function extractFocusArgsForCourse(html: string, courseId: number): Record<string, unknown> {
+	const needle = `data-guid="${courseId}"`;
+	const idx = html.indexOf(needle);
+	if (idx === -1) throw new Error(`Course ${courseId} was not found on the gradebook page`);
+
+	const slice = html.slice(idx, idx + 8000);
+	const quoted = slice.match(/data-focus="([^"]+)"/) ?? slice.match(/data-focus='([^']+)'/);
+	if (quoted?.[1] === undefined) {
+		throw new Error(`Could not read class details for course ${courseId}`);
+	}
+
+	const parsed: unknown = JSON.parse(decodeHtmlAttr(quoted[1]));
+	if (typeof parsed !== 'object' || parsed === null) {
+		throw new Error(`Invalid class focus data for course ${courseId}`);
+	}
+
+	const record = parsed as Record<string, unknown>;
+	const focusArgs = record.FocusArgs;
+	if (typeof focusArgs === 'object' && focusArgs !== null) {
+		return focusArgs as Record<string, unknown>;
+	}
+
+	return record;
+}
+
+export function extractCourseChrome(
+	html: string,
+	courseId: number
+): { room: string; markPreview: string; scorePreview: string } {
+	const needle = `data-guid="${courseId}"`;
+	const idx = html.indexOf(needle);
+	if (idx === -1) {
+		return { room: '', markPreview: '', scorePreview: '' };
+	}
+
+	const slice = html.slice(idx, idx + 8000);
+	const roomMatch = slice.match(/teacher-room[^>]*>([^<]*)/i);
+	const markMatch = slice.match(/class="mark"[^>]*>([^<]*)/i);
+	const scoreMatch = slice.match(/class="score"[^>]*>([^<]*)/i);
+
+	return {
+		room: (roomMatch?.[1] ?? '').replace(/^Room:\s*/i, '').trim(),
+		markPreview: (markMatch?.[1] ?? '').trim(),
+		scorePreview: (scoreMatch?.[1] ?? '').trim()
+	};
+}
+
+const PXP_PLACEHOLDER = /(?<=:)PXP\.\w+\.\w+(?=[,}\]])/g;
+
+export function extractAssignmentNames(html: string): Record<number, string> {
+	const marker = '.dxDataGrid(PXP.DevExpress.ExtendGridConfiguration(';
+	const start = html.lastIndexOf(marker);
+	if (start === -1) return {};
+
+	const rest = html.slice(start + marker.length);
+	const line = rest.split(/\r?\n/, 1)[0] ?? rest;
+	const close = line.lastIndexOf('}');
+	if (close === -1) return {};
+	const raw = line.slice(0, close + 1).replace(PXP_PLACEHOLDER, '""');
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return {};
+	}
+
+	if (typeof parsed !== 'object' || parsed === null || !('dataSource' in parsed)) return {};
+
+	const dataSource = (parsed as { dataSource: unknown }).dataSource;
+	if (!Array.isArray(dataSource)) return {};
+
+	const names: Record<number, string> = {};
+	for (const record of dataSource) {
+		if (typeof record !== 'object' || record === null) continue;
+		const row = record as { gradeBookId?: unknown; GBAssignment?: unknown };
+		const id = Number(row.gradeBookId);
+		if (!Number.isFinite(id)) continue;
+
+		let name: string | undefined;
+		if (typeof row.GBAssignment === 'string') {
+			try {
+				const wrapped: unknown = JSON.parse(row.GBAssignment);
+				if (typeof wrapped === 'object' && wrapped !== null && 'value' in wrapped) {
+					const value = (wrapped as { value: unknown }).value;
+					if (typeof value === 'string') name = value;
+				}
+			} catch {
+				name = row.GBAssignment;
+			}
+		}
+
+		if (name !== undefined && name.length > 0) names[id] = name;
+	}
+
+	return names;
+}

--- a/src/lib/pxp2/paths.ts
+++ b/src/lib/pxp2/paths.ts
@@ -1,0 +1,24 @@
+const ALLOWED_PATHS = [
+	'/PXP2_Login_Student.aspx',
+	'/PXP2_GradeBook.aspx',
+	'/service/PXP2Communication.asmx/LoadControl',
+	'/service/PXP2Communication.asmx/GradebookFocusClassInfo',
+	'/api/GB/ClientSideData/Transfer',
+	'/api/v1/components/pxp/student-picker/StudentPicker/GetStudents'
+] as const;
+
+export function pathnameOf(path: string): string {
+	return path.split('?')[0] ?? path;
+}
+
+export function isAllowedStudentVuePath(path: string): boolean {
+	if (!path.startsWith('/')) return false;
+	const pathname = pathnameOf(path);
+	return ALLOWED_PATHS.some((allowed) => pathname === allowed);
+}
+
+export function assertAllowedStudentVuePath(path: string): void {
+	if (!isAllowedStudentVuePath(path)) {
+		throw new Error(`Blocked StudentVUE path: ${pathnameOf(path)}`);
+	}
+}

--- a/src/lib/pxp2/protocol.ts
+++ b/src/lib/pxp2/protocol.ts
@@ -1,0 +1,26 @@
+export const PAGE_SOURCE = 'gradecompass-page';
+export const BRIDGE_SOURCE = 'gradecompass-bridge';
+
+export type BridgeRequest =
+	| { type: 'ping' }
+	| { type: 'hasSession'; domain: string }
+	| { type: 'beginLogin'; domain: string }
+	| { type: 'gradebook'; domain: string; reportPeriod?: number }
+	| { type: 'studentInfo'; domain: string };
+
+export type BridgeSuccess<T> = { ok: true; data: T };
+export type BridgeFailure = { ok: false; error: string };
+export type BridgeResponse<T = unknown> = BridgeSuccess<T> | BridgeFailure;
+
+export interface Pxp2StudentInfo {
+	name: string;
+	sisNumber: string;
+	schoolName: string;
+	schoolPhone: string;
+	photoUrl: string;
+}
+
+export interface SessionResult {
+	loggedIn: boolean;
+	student?: Pxp2StudentInfo;
+}

--- a/src/lib/pxp2/types.ts
+++ b/src/lib/pxp2/types.ts
@@ -1,0 +1,86 @@
+export interface Pxp2GradingPeriod {
+	Name: string;
+	GroupName: string;
+	GU: string;
+	OrgYearGU: string;
+	schoolID: number;
+	defaultFocus: boolean;
+	MarkPeriods?: Array<{ GU: string }>;
+}
+
+export interface Pxp2GbFocusData {
+	GradingPeriods: Pxp2GradingPeriod[];
+}
+
+export interface Pxp2CourseMetadata {
+	ID: number;
+	Name: string;
+	TeacherName: string;
+	room?: string;
+	markPreview?: string | null;
+	scorePreview?: string | null;
+}
+
+export interface Pxp2MeasureType {
+	id: number;
+	name: string;
+	weight: number;
+}
+
+export interface Pxp2ClassGrade {
+	studentId?: number;
+	assignmentCount?: number;
+	points: number;
+	pointsPossible: number;
+	calculatedMark: string;
+	totalWeightedPercentage?: number;
+	percentage?: number;
+}
+
+export interface Pxp2MeasureTypeGrade {
+	measureTypeId: number;
+	measureTypeWeight: number;
+	points: number;
+	pointsPossible: number;
+	calculatedMark: string;
+}
+
+export interface Pxp2Assignment {
+	category: string;
+	commentCode: string | null;
+	dueDate: string;
+	excused: boolean;
+	gradeBookCategoryId: number;
+	gradeBookId: number;
+	isForGrading: boolean;
+	maxScore: string;
+	maxValue?: number;
+	measureTypeId: number;
+	name?: string;
+	score: string | null;
+	studentId: number;
+}
+
+export interface Pxp2ClassData {
+	assignments: Pxp2Assignment[];
+	classGrades: Pxp2ClassGrade[];
+	classId: number;
+	className: string | number;
+	gradingPeriodId?: number;
+	measureTypeGrades: Pxp2MeasureTypeGrade[];
+	measureTypes?: Pxp2MeasureType[];
+}
+
+export interface Pxp2CourseInput {
+	metadata: Pxp2CourseMetadata;
+	classData: Pxp2ClassData;
+	assignmentNames: Record<number, string>;
+	measureTypes: Pxp2MeasureType[];
+}
+
+export interface MapGradebookInput {
+	periods: Pxp2GradingPeriod[];
+	activePeriod: Pxp2GradingPeriod;
+	activeIndex: number;
+	courses: Pxp2CourseInput[];
+}

--- a/src/lib/synergy.ts
+++ b/src/lib/synergy.ts
@@ -36,7 +36,7 @@ const alwaysArray = [
 	'Gradebook.ReportingPeriods.ReportPeriod',
 	'Attendance.Absences.Absence',
 	'SynergyMailDataXML.InboxItemListings.MessageXML',
-	'StudentDocuments.StudentDocumentDatas.StudentDocumentData',
+	'StudentDocuments.StudentDocumentDatas.StudentDocumentData'
 ];
 
 const envelopeParser = new XMLParser({ ignoreDeclaration: true });
@@ -167,15 +167,27 @@ const webServiceRequestMultiWeb = <T>(
 export const parseGradebookXML = (resultStr: string) =>
 	convertEmptyElementToNull(parseResult<GradebookResult>(resultStr).Gradebook);
 
+export type AccountMode = 'soap' | 'pxp2';
+
+function pxp2Unavailable(feature: string): Error {
+	return new Error(`${feature} is not available with the companion extension yet`);
+}
+
 export class StudentAccount {
 	domain: string;
 	userID: string;
 	password: string;
+	mode: AccountMode;
 
-	constructor(domain: string, userID: string, password: string) {
+	constructor(domain: string, userID: string, password: string, mode: AccountMode = 'soap') {
 		this.domain = domain;
 		this.userID = userID;
 		this.password = password;
+		this.mode = mode;
+	}
+
+	static fromPxp2(domain: string) {
+		return new StudentAccount(domain, '', '', 'pxp2');
 	}
 
 	get credentials(): Credentials {
@@ -187,32 +199,75 @@ export class StudentAccount {
 	}
 
 	async checkLogin() {
+		if (this.mode === 'pxp2') {
+			const { bridgeRequest } = await import('$lib/bridge');
+			await bridgeRequest({ type: 'beginLogin', domain: this.domain }, 6 * 60 * 1000);
+			return;
+		}
+
 		await webServiceRequest<StudentInfoResult>('StudentInfo', this.credentials);
 	}
 
+	async fetchPxp2Gradebook(reportPeriod?: number) {
+		const { bridgeRequest } = await import('$lib/bridge');
+		return await bridgeRequest<import('$lib/types/Gradebook').Gradebook>({
+			type: 'gradebook',
+			domain: this.domain,
+			reportPeriod
+		});
+	}
+
 	async gradebookRequest(reportPeriod?: number) {
+		if (this.mode === 'pxp2') throw pxp2Unavailable('SOAP gradebook');
+
 		// When a specific report period is requested, if it is not available Synergy returns the current report period
-		const params = reportPeriod ? { ReportPeriod: reportPeriod } : undefined;
+		const params = reportPeriod !== undefined ? { ReportPeriod: reportPeriod } : undefined;
 
 		return await fetchSoap(Operation.Request, MethodName.Gradebook, this.credentials, params);
 	}
 
 	async attendance() {
+		if (this.mode === 'pxp2') throw pxp2Unavailable('Attendance');
+
 		return (await webServiceRequest<AttendanceResult>(MethodName.Attendance, this.credentials))
 			.Attendance;
 	}
 
 	async studentInfo() {
+		if (this.mode === 'pxp2') {
+			const { bridgeRequest } = await import('$lib/bridge');
+			const info = await bridgeRequest<import('$lib/pxp2/protocol').Pxp2StudentInfo>({
+				type: 'studentInfo',
+				domain: this.domain
+			});
+
+			return {
+				FormattedName: info.name,
+				PermID: Number.parseInt(info.sisNumber, 10) || 0,
+				Gender: '',
+				Grade: 0,
+				Photo: '',
+				'_xmlns:xsd': '',
+				'_xmlns:xsi': '',
+				_Type: '',
+				_ShowPhysicianAndDentistInfo: 'false'
+			};
+		}
+
 		return (await webServiceRequest<StudentInfoResult>(MethodName.StudentInfo, this.credentials))
 			.StudentInfo;
 	}
 
 	async documents() {
+		if (this.mode === 'pxp2') throw pxp2Unavailable('Documents');
+
 		return (await webServiceRequest<DocumentsResult>(MethodName.Documents, this.credentials))
 			.StudentDocuments;
 	}
 
 	async reportCard(documentGU: string) {
+		if (this.mode === 'pxp2') throw pxp2Unavailable('Report cards');
+
 		return (
 			await webServiceRequest<ReportCardResult>(MethodName.ReportCard, this.credentials, {
 				DocumentGU: documentGU
@@ -221,11 +276,15 @@ export class StudentAccount {
 	}
 
 	async mailData() {
+		if (this.mode === 'pxp2') throw pxp2Unavailable('Mail');
+
 		return (await webServiceRequest<MailResult>(MethodName.Mail, this.credentials))
 			.SynergyMailDataXML;
 	}
 
 	async attachment(attachmentGU: string) {
+		if (this.mode === 'pxp2') throw pxp2Unavailable('Mail attachments');
+
 		return (
 			await webServiceRequest<AttachmentResult>(MethodName.Attachment, this.credentials, {
 				SmAttachmentGU: attachmentGU
@@ -234,6 +293,8 @@ export class StudentAccount {
 	}
 
 	async getAuthToken() {
+		if (this.mode === 'pxp2') throw pxp2Unavailable('Auth tokens');
+
 		return (
 			await webServiceRequestMultiWeb<AuthTokenResult>('GenerateAuthToken', this.credentials, {
 				Username: this.userID,

--- a/src/routes/(authed)/AppSidebar.svelte
+++ b/src/routes/(authed)/AppSidebar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { removeCourseType } from '$lib';
+	import { acc } from '$lib/account.svelte';
 	import { brand } from '$lib/brand';
 	import { buttonVariants } from '$lib/components/ui/button';
 	import Button from '$lib/components/ui/button/button.svelte';
@@ -181,7 +182,9 @@
 			</Sidebar.MenuItem>
 
 			{#each data.header as item (item.title)}
-				{@render menuItem(item)}
+				{#if acc.studentAccount?.mode !== 'pxp2'}
+					{@render menuItem(item)}
+				{/if}
 			{/each}
 		</Sidebar.Menu>
 
@@ -191,7 +194,7 @@
 				variant="ghost"
 				class="text-muted-foreground h-auto border py-3 text-xs whitespace-normal"
 			>
-				Your password and grades are private and stored on-device.
+				Your grades are private and stored on-device.
 			</Button>
 		</Sidebar.MenuItem>
 	</Sidebar.Content>

--- a/src/routes/(authed)/grades/data/+page.svelte
+++ b/src/routes/(authed)/grades/data/+page.svelte
@@ -17,7 +17,7 @@
 	);
 </script>
 
-<div class="m-4 flex flex-col gap-4 h-full items-center">
+<div class="m-4 flex h-full flex-col items-center gap-4">
 	{#if gradebookCatalog && gradebook}
 		<ReportPeriodSwitcher
 			activeName={gradebook?.ReportingPeriod._GradePeriod}
@@ -32,6 +32,11 @@
 	{/if}
 
 	{#if gradebookRecord}
-		<Textarea value={gradebookRecord.xml} class="h-full" />
+		<Textarea
+			value={gradebookRecord.gradebook
+				? JSON.stringify(gradebookRecord.gradebook, null, 2)
+				: (gradebookRecord.xml ?? '')}
+			class="h-full"
+		/>
 	{/if}
 </div>

--- a/src/routes/(authed)/studentinfo/+page.svelte
+++ b/src/routes/(authed)/studentinfo/+page.svelte
@@ -87,15 +87,21 @@
 				<div class="space-y-2">
 					<p>{studentInfoState.data.FormattedName}</p>
 					<p class="text-muted-foreground">{studentInfoState.data.PermID}</p>
-					<p class="text-muted-foreground">Grade {studentInfoState.data.Grade}</p>
-					<p class="text-muted-foreground">{studentInfoState.data.Gender}</p>
+					{#if studentInfoState.data.Grade > 0}
+						<p class="text-muted-foreground">Grade {studentInfoState.data.Grade}</p>
+					{/if}
+					{#if studentInfoState.data.Gender.length > 0}
+						<p class="text-muted-foreground">{studentInfoState.data.Gender}</p>
+					{/if}
 				</div>
 
-				<img
-					src="data:image/png;base64,{studentInfoState.data.Photo}"
-					class="h-full rounded-sm"
-					alt="Student Portrait"
-				/>
+				{#if studentInfoState.data.Photo.length > 0}
+					<img
+						src="data:image/png;base64,{studentInfoState.data.Photo}"
+						class="h-full rounded-sm"
+						alt="Student Portrait"
+					/>
+				{/if}
 			</Card.Content>
 		</Card.Root>
 	{/if}
@@ -109,36 +115,38 @@
 
 			<Card.Content>
 				<dl>
-					<dt>Username</dt>
-					<dd class="flex items-center justify-end gap-2">
-						{acc.studentAccount.userID}
-						<Button onclick={copyUsername} variant="outline" size="icon-sm" title="Copy username">
-							<CopyIcon />
-						</Button>
-					</dd>
-					<dt>Password</dt>
-					<dd class="flex items-center justify-end gap-2">
-						<span class="{showPassword ? '' : 'blur select-none'} transition-all">
-							{#if showPassword}
-								{acc.studentAccount.password}
-							{:else}
-								#Wa5$^yB%4R#6K^C
-							{/if}
-						</span>
-						{#if !showPassword}
-							<Button
-								onclick={togglePassword}
-								variant="outline"
-								size="icon-sm"
-								title="Show password"
-							>
-								<EyeIcon />
+					{#if acc.studentAccount.mode !== 'pxp2'}
+						<dt>Username</dt>
+						<dd class="flex items-center justify-end gap-2">
+							{acc.studentAccount.userID}
+							<Button onclick={copyUsername} variant="outline" size="icon-sm" title="Copy username">
+								<CopyIcon />
 							</Button>
-						{/if}
-						<Button onclick={copyPassword} variant="outline" size="icon-sm" title="Copy password">
-							<CopyIcon />
-						</Button>
-					</dd>
+						</dd>
+						<dt>Password</dt>
+						<dd class="flex items-center justify-end gap-2">
+							<span class="{showPassword ? '' : 'blur select-none'} transition-all">
+								{#if showPassword}
+									{acc.studentAccount.password}
+								{:else}
+									#Wa5$^yB%4R#6K^C
+								{/if}
+							</span>
+							{#if !showPassword}
+								<Button
+									onclick={togglePassword}
+									variant="outline"
+									size="icon-sm"
+									title="Show password"
+								>
+									<EyeIcon />
+								</Button>
+							{/if}
+							<Button onclick={copyPassword} variant="outline" size="icon-sm" title="Copy password">
+								<CopyIcon />
+							</Button>
+						</dd>
+					{/if}
 					<dt>Domain</dt>
 					<dd class="flex items-center justify-end gap-2">
 						{acc.studentAccount.domain}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,8 +13,9 @@
 	import ChartLineIcon from '@lucide/svelte/icons/chart-line';
 	import FolderLockIcon from '@lucide/svelte/icons/folder-lock';
 	import GithubIcon from '@lucide/svelte/icons/github';
+	import LogInIcon from '@lucide/svelte/icons/log-in';
 	import PlayIcon from '@lucide/svelte/icons/play';
-	import PowerIcon from '@lucide/svelte/icons/power';
+	import PuzzleIcon from '@lucide/svelte/icons/puzzle';
 
 	if (browser && localStorage.getItem(LocalStorageKey.token) !== null && !demoState.enabled) {
 		if (!acc.studentAccount) loadStudentAccount();
@@ -42,7 +43,7 @@
 		{
 			icon: FolderLockIcon,
 			title: 'Private Login',
-			description: `${brand} did not have access to your data. When you used ${brand}, your device connected directly to your student portal. We never saw your password or your grades! `,
+			description: `${brand} does not have access to your data. You log in on the official student portal; the companion extension keeps cookies in the browser and GradeCompass processes grades on-device.`,
 			link: { href: '/privacy', text: 'Learn more' }
 		}
 	];
@@ -71,17 +72,24 @@
 					<Card.Content>
 						<p>An advanced grade calculator.</p>
 
-						<Alert.Root variant="destructive" class="mt-4">
-							<PowerIcon />
-							<Alert.Title>GradeCompass is now obsolete.</Alert.Title>
+						<Alert.Root class="mt-4">
+							<PuzzleIcon />
+							<Alert.Title>StudentVUE login needs the companion extension</Alert.Title>
 							<Alert.Description>
-								<a href="/obsolete" class="underline">Learn more</a>
+								The old portal protocol is gone. Install the companion extension to log in
+								on-device, or try the demo.
+								<p>
+									<a href="/obsolete" class="underline">Learn more</a>
+								</p>
 							</Alert.Description>
 						</Alert.Root>
 					</Card.Content>
 
 					<Card.Footer class="flex gap-2">
-						<Button size="lg" variant="card" class="flex-1" onclick={openDemo}>
+						<Button size="lg" variant="card" class="flex-1" href="/login">
+							<LogInIcon /> Log in
+						</Button>
+						<Button size="lg" variant="outline" class="flex-1" onclick={openDemo}>
 							<PlayIcon /> Try demo
 						</Button>
 					</Card.Footer>

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { LocalStorageKey } from '$lib';
 	import { acc, loadStudentAccount } from '$lib/account.svelte';
+	import { pingBridge } from '$lib/bridge';
 	import { brand } from '$lib/brand';
 	import LoadingBanner from '$lib/components/LoadingBanner.svelte';
 	import * as Alert from '$lib/components/ui/alert';
@@ -13,11 +14,13 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { openDemo } from '$lib/demo/demo.svelte';
+	import { normalizeDomain } from '$lib/pxp2/domain';
 	import { StudentAccount } from '$lib/synergy';
 	import AlertCircleIcon from '@lucide/svelte/icons/alert-circle';
 	import InfoIcon from '@lucide/svelte/icons/info';
 	import LogInIcon from '@lucide/svelte/icons/log-in';
-	import PowerIcon from '@lucide/svelte/icons/power';
+	import PuzzleIcon from '@lucide/svelte/icons/puzzle';
+	import { onMount } from 'svelte';
 	import { fly } from 'svelte/transition';
 
 	if (browser && localStorage.getItem(LocalStorageKey.token) !== null) {
@@ -26,37 +29,47 @@
 		void goto('/grades');
 	}
 
-	let username: string = $state('');
-	let password: string = $state('');
 	let domain: string = $state('');
-
 	let loginError: string | undefined = $state();
-
 	let loggingIn = $state(false);
+	let bridgeStatus: 'checking' | 'available' | 'missing' = $state('checking');
+
+	onMount(() => {
+		void pingBridge().then((available) => {
+			bridgeStatus = available ? 'available' : 'missing';
+		});
+	});
 
 	async function login(event: SubmitEvent) {
 		event.preventDefault();
 
-		if (loggingIn) return;
+		if (loggingIn || bridgeStatus !== 'available') return;
 		loggingIn = true;
+		loginError = undefined;
 
-		const loginAccount = new StudentAccount(domain, username, password);
+		let host: string;
+		try {
+			host = normalizeDomain(domain);
+		} catch (error) {
+			loggingIn = false;
+			loginError = error instanceof Error ? error.message : String(error);
+			return;
+		}
+
+		const loginAccount = StudentAccount.fromPxp2(host);
 
 		try {
 			await loginAccount.checkLogin();
 		} catch (error) {
 			loggingIn = false;
-
 			loginError = error instanceof Error ? error.message : String(error);
 			return;
 		}
 
 		acc.studentAccount = loginAccount;
-
-		localStorage.setItem(LocalStorageKey.token, JSON.stringify({ username, password, domain }));
+		localStorage.setItem(LocalStorageKey.token, JSON.stringify({ domain: host, mode: 'pxp2' }));
 
 		loggingIn = false;
-
 		void goto('/grades');
 	}
 
@@ -64,7 +77,7 @@
 	const convertedDomain = $derived.by(() => {
 		try {
 			const url = new URL(pastedUrl);
-			return url.host;
+			return url.host.replace(/:\d+$/, '');
 		} catch {
 			return undefined;
 		}
@@ -79,8 +92,6 @@
 	function openDomainDialog() {
 		domainDialogOpen = true;
 	}
-
-	const disabled = true;
 </script>
 
 <svelte:head>
@@ -88,7 +99,7 @@
 </svelte:head>
 
 {#if loggingIn}
-	<LoadingBanner>Logging you in...</LoadingBanner>
+	<LoadingBanner>Waiting for StudentVUE login...</LoadingBanner>
 {/if}
 
 {#if loginError}
@@ -110,47 +121,35 @@
 				<h1 class="text-xl font-bold">Log in to {brand}</h1>
 			</div>
 
-			<Alert.Root variant="destructive" class="mb-4">
-				<PowerIcon />
-				<Alert.Title>GradeCompass is now obsolete.</Alert.Title>
-				<Alert.Description>
-					You will see a deprecation notice if you try to log in.
-					<p>
-						<a href="/obsolete" class="underline">Learn more</a> •
-						<button class="cursor-pointer underline" onclick={openDemo}>Open demo</button>
-					</p>
-				</Alert.Description>
-			</Alert.Root>
+			{#if bridgeStatus === 'missing'}
+				<Alert.Root variant="destructive" class="mb-4">
+					<PuzzleIcon />
+					<Alert.Title>Companion extension required</Alert.Title>
+					<Alert.Description>
+						The StudentVUE protocol no longer allows a website to log in by itself. Install the
+						GradeCompass companion extension, then return here. Your password stays on the official
+						portal.
+						<p>
+							<a href="/obsolete" class="underline">Learn more</a> •
+							<button class="cursor-pointer underline" onclick={openDemo} type="button">
+								Open demo
+							</button>
+						</p>
+					</Alert.Description>
+				</Alert.Root>
+			{:else if bridgeStatus === 'available'}
+				<Alert.Root class="mb-4">
+					<PuzzleIcon />
+					<Alert.Title>Companion extension connected</Alert.Title>
+					<Alert.Description>
+						You'll log in on your district's StudentVUE site. {brand} never sees your password; grades
+						stay on this device.
+					</Alert.Description>
+				</Alert.Root>
+			{/if}
 
 			<div class="relative">
 				<Field.Group>
-					<Field.Field>
-						<Field.Label for="username">Username</Field.Label>
-						<Input
-							id="username"
-							type="text"
-							bind:value={username}
-							placeholder="student@school.net"
-							autocomplete="username"
-							required
-						/>
-					</Field.Field>
-
-					<Field.Field>
-						<Field.Label for="password">Password</Field.Label>
-						<Input
-							type="password"
-							id="password"
-							bind:value={password}
-							autocomplete="current-password"
-							required
-						/>
-						<Field.Description>
-							Your device connected directly to the portal. We couldn't see your password or your
-							grades.
-						</Field.Description>
-					</Field.Field>
-
 					<Field.Field>
 						<Field.Label for="domain">Your District's Portal Domain</Field.Label>
 
@@ -158,7 +157,7 @@
 							<InfoIcon />
 							<Alert.Title class="line-clamp-none">
 								{brand} could
-								<button onclick={openDomainDialog} class="underline">
+								<button onclick={openDomainDialog} class="underline" type="button">
 									find your domain for you
 								</button>.
 							</Alert.Title>
@@ -172,6 +171,7 @@
 							autocorrect="off"
 							bind:value={domain}
 							required
+							disabled={bridgeStatus !== 'available'}
 						/>
 					</Field.Field>
 
@@ -195,10 +195,15 @@
 					</Dialog.Root>
 
 					<Field.Field orientation="horizontal" class="items-center">
-						<Checkbox name="disclaimer" id="disclaimer" required />
+						<Checkbox
+							name="disclaimer"
+							id="disclaimer"
+							required
+							disabled={bridgeStatus !== 'available'}
+						/>
 
 						<Field.Label for="disclaimer" class="text-tertiary-foreground text-xs">
-							I understand that {brand} was an independent, unofficial tool and is not affiliated with
+							I understand that {brand} is an independent, unofficial tool and is not affiliated with
 							or endorsed by Edupoint Educational Systems LLC. Use of your district's portal is subject
 							to Edupoint Educational Systems LLC's terms of service, and I am responsible for ensuring
 							my use complies with those terms.
@@ -206,13 +211,18 @@
 					</Field.Field>
 
 					<Field.Field>
-						<Button type="submit" class="w-full" variant="card">
-							<LogInIcon class="h-4 w-4" /> Log in
+						<Button
+							type="submit"
+							class="w-full"
+							variant="card"
+							disabled={bridgeStatus !== 'available'}
+						>
+							<LogInIcon class="h-4 w-4" /> Continue to StudentVUE
 						</Button>
 					</Field.Field>
 				</Field.Group>
 
-				{#if disabled}
+				{#if bridgeStatus !== 'available'}
 					<div class="absolute -inset-2 backdrop-blur-xs" aria-hidden="true"></div>
 				{/if}
 			</div>

--- a/src/routes/obsolete/+page.svelte
+++ b/src/routes/obsolete/+page.svelte
@@ -4,58 +4,41 @@
 </script>
 
 <svelte:head>
-	<title>{brand} is now obsolete</title>
+	<title>{brand} and the new StudentVUE protocol</title>
 </svelte:head>
 
 <div class="flex min-h-screen flex-col items-center">
 	<main class="flex grow items-center">
 		<Card.Root class="m-4 max-w-xl">
 			<Card.Header>
-				<Card.Title>{brand} is now obsolete</Card.Title>
+				<Card.Title>The old StudentVUE protocol is gone</Card.Title>
 			</Card.Header>
 
 			<Card.Content class="text-tertiary-foreground space-y-4">
-				<p class="italic">December 2023 - July 2026</p>
+				<p class="italic">December 2023 - July 2026 as a website-only login</p>
 
 				<p>
 					If you've been logged in to GradeCompass, you may see an error message saying that the app
 					is deprecated. This is because the student portal software that GradeCompass is designed
-					for has been updated, and the protocol that GradeCompass uses is no longer supported.
+					for has been updated, and the SOAP protocol that GradeCompass used is no longer supported.
 				</p>
 
 				<p>
-					This isn't something that's under our control. Unfortunately, this means that GradeCompass
-					will no longer work starting in the 2026-2027 school year.
+					A website cannot attach a StudentVUE login session anymore: the new protocol uses HttpOnly
+					SameSite cookies, and cross-origin requests are not allowed to send those credentials.
+					GradeCompass still will not send your data through a server.
 				</p>
 
 				<p>
-					We'd like to thank the tens of thousands of students who have used GradeCompass over the
-					years. We're honored to have built something that directly served so many people.
-				</p>
-
-				<p class="text-secondary-foreground">
-					Why can't GradeCompass be updated to work with the new version?
-				</p>
-
-				<p>
-					From the start, GradeCompass was designed so that your data is securely retrieved and
-					processed on your device directly. This was only possible due to how the original protocol
-					was configured. The new protocol is not configured in this way, meaning that any website
-					that works with the new protocol must send your data through its servers, compromising
-					your privacy.
+					The companion browser extension is the on-device bridge. You log in on the official
+					StudentVUE site; the extension reads gradebook data with your browser cookies and hands
+					JSON to GradeCompass running locally. See the
+					<a href={repoLink} class="underline">README</a> for install instructions.
 				</p>
 
 				<p>
-					Updating to the new protocol would undermine this core principle of GradeCompass. It would
-					also require significant development work to rewrite much of GradeCompass's code. As such,
-					GradeCompass will not be updated. It will remain in a demo-only state.
-				</p>
-
-				<p class="text-secondary-foreground">What about GradeCompass's code?</p>
-
-				<p>
-					GradeCompass's code is <a href={repoLink} class="underline">open source</a> under the MIT license.
-					You are welcome to reuse its code or designs in your own projects. Attribution is always appreciated.
+					<a href="/login" class="underline">Log in</a> •
+					<a href="/" class="underline">Home</a>
 				</p>
 			</Card.Content>
 		</Card.Root>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -24,14 +24,14 @@
 				</p>
 
 				<p>
-					When a student used the {brand} interface, their own device transmitted their username and password
-					directly to the official student portal, which returned their student information directly to
-					their device.
+					When a student uses the {brand} interface with the companion extension, they log in on the official
+					student portal. The extension reads gradebook data using the browser's cookies and returns it
+					to this page. {brand} servers do not receive student data or login information.
 				</p>
 
 				<p>
-					{brand} servers did not receive any student data or login information. The GradeCompass interface
-					was purely client-side: all data was retrieved, processed, and stored on-device.
+					Without the extension, {brand} can only run its on-device demo. The website cannot talk to the
+					new StudentVUE protocol by itself.
 				</p>
 
 				<p>

--- a/src/tests/pxp2-map.test.ts
+++ b/src/tests/pxp2-map.test.ts
@@ -1,0 +1,185 @@
+import { parseSynergyAssignment } from '$lib/grades/assignments';
+import { mapGradebook } from '$lib/pxp2/mapGradebook';
+import type { MapGradebookInput } from '$lib/pxp2/types';
+import { expect, test } from 'bun:test';
+
+const fixture: MapGradebookInput = {
+	periods: [
+		{
+			Name: 'Quarter 1',
+			GroupName: 'Q1',
+			GU: 'gp-1',
+			OrgYearGU: 'oy-1',
+			schoolID: 1,
+			defaultFocus: true
+		},
+		{
+			Name: 'Quarter 2',
+			GroupName: 'Q2',
+			GU: 'gp-2',
+			OrgYearGU: 'oy-1',
+			schoolID: 1,
+			defaultFocus: false
+		}
+	],
+	activePeriod: {
+		Name: 'Quarter 1',
+		GroupName: 'Q1',
+		GU: 'gp-1',
+		OrgYearGU: 'oy-1',
+		schoolID: 1,
+		defaultFocus: true
+	},
+	activeIndex: 0,
+	courses: [
+		{
+			metadata: {
+				ID: 101,
+				Name: 'Algebra 1',
+				TeacherName: 'Ms. Rivera',
+				room: 'B12',
+				markPreview: 'A',
+				scorePreview: '92.5%'
+			},
+			measureTypes: [
+				{ id: 1, name: 'Homework', weight: 20 },
+				{ id: 2, name: 'Tests', weight: 80 }
+			],
+			assignmentNames: { 9001: 'HW 1.1' },
+			classData: {
+				classId: 101,
+				className: 'Algebra 1',
+				assignments: [
+					{
+						category: 'Homework',
+						commentCode: null,
+						dueDate: '8/18/2025',
+						excused: false,
+						gradeBookCategoryId: 1,
+						gradeBookId: 9001,
+						isForGrading: true,
+						maxScore: '10',
+						measureTypeId: 1,
+						score: '9',
+						studentId: 42
+					},
+					{
+						category: 'Tests',
+						commentCode: null,
+						dueDate: '8/25/2025',
+						excused: false,
+						gradeBookCategoryId: 2,
+						gradeBookId: 9002,
+						isForGrading: true,
+						maxScore: '100',
+						measureTypeId: 2,
+						name: 'Unit 1 Test',
+						score: '94',
+						studentId: 42
+					},
+					{
+						category: 'Homework',
+						commentCode: null,
+						dueDate: '8/26/2025',
+						excused: false,
+						gradeBookCategoryId: 1,
+						gradeBookId: 9003,
+						isForGrading: false,
+						maxScore: '5',
+						measureTypeId: 1,
+						name: 'Practice',
+						score: '5',
+						studentId: 42
+					}
+				],
+				classGrades: [
+					{
+						points: 103,
+						pointsPossible: 110,
+						calculatedMark: 'A',
+						totalWeightedPercentage: 0.925
+					}
+				],
+				measureTypeGrades: [
+					{
+						measureTypeId: 1,
+						measureTypeWeight: 20,
+						points: 9,
+						pointsPossible: 10,
+						calculatedMark: 'A'
+					},
+					{
+						measureTypeId: 2,
+						measureTypeWeight: 80,
+						points: 94,
+						pointsPossible: 100,
+						calculatedMark: 'A'
+					}
+				]
+			}
+		}
+	]
+};
+
+test('maps PXP2 JSON into the existing Gradebook shape', () => {
+	const gradebook = mapGradebook(fixture);
+
+	expect(gradebook.ReportingPeriods.ReportPeriod).toHaveLength(2);
+	expect(gradebook.ReportingPeriod._GradePeriod).toBe('Quarter 1');
+	expect(gradebook.ReportingPeriod._Index).toBe('0');
+
+	const course = gradebook.Courses.Course[0];
+	expect(course?._CourseName).toBe('Algebra 1');
+	expect(course?._Staff).toBe('Ms. Rivera');
+	expect(course?._Room).toBe('B12');
+
+	const mark = course?.Marks?.Mark[0];
+	expect(mark?._CalculatedScoreString).toBe('A');
+	expect(mark?._CalculatedScoreRaw).toBe('92.5');
+	expect(mark?.GradeCalculationSummary?.AssignmentGradeCalc).toEqual([
+		{
+			_Type: 'Homework',
+			_Weight: '20%',
+			_Points: '9',
+			_PointsPossible: '10',
+			_WeightedPct: '18%',
+			_CalculatedMark: 'A'
+		},
+		{
+			_Type: 'Tests',
+			_Weight: '80%',
+			_Points: '94',
+			_PointsPossible: '100',
+			_WeightedPct: '75.2%',
+			_CalculatedMark: 'A'
+		}
+	]);
+
+	expect(mark?.Assignments?.Assignment).toHaveLength(3);
+});
+
+test('mapped assignments are readable by parseSynergyAssignment', () => {
+	const gradebook = mapGradebook(fixture);
+	const assignments = gradebook.Courses.Course[0]?.Marks?.Mark[0]?.Assignments?.Assignment ?? [];
+
+	expect(parseSynergyAssignment(assignments[0]!)).toMatchObject({
+		name: 'HW 1.1',
+		id: '9001',
+		pointsEarned: 9,
+		pointsPossible: 10,
+		category: 'Homework',
+		notForGrade: false
+	});
+
+	expect(parseSynergyAssignment(assignments[1]!)).toMatchObject({
+		name: 'Unit 1 Test',
+		pointsEarned: 94,
+		pointsPossible: 100,
+		category: 'Tests'
+	});
+
+	expect(parseSynergyAssignment(assignments[2]!)).toMatchObject({
+		name: 'Practice',
+		notForGrade: true
+	});
+});

--- a/src/tests/pxp2-parse.test.ts
+++ b/src/tests/pxp2-parse.test.ts
@@ -1,0 +1,63 @@
+import { normalizeDomain } from '$lib/pxp2/domain';
+import {
+	extractAssignmentNames,
+	extractCourseChrome,
+	extractFocusArgsForCourse,
+	extractGbFocusData
+} from '$lib/pxp2/parse';
+import { isAllowedStudentVuePath } from '$lib/pxp2/paths';
+import { expect, test } from 'bun:test';
+
+const gradebookHtml = `
+<script>
+PXP.GBFocusData = {"GradingPeriods":[{"Name":"Quarter 1","GroupName":"Q1","GU":"abc","OrgYearGU":"oy","schoolID":9,"defaultFocus":true}]};
+</script>
+<div data-guid="101">
+  <div class="teacher-room">Room: B12</div>
+  <span class="mark">A</span>
+  <span class="score">92.5%</span>
+  <button data-focus="{&quot;FocusArgs&quot;:{&quot;classID&quot;:101,&quot;AGU&quot;:0}}">Open</button>
+</div>
+`;
+
+const classDetailsHtml = `
+<div class="dx-datagrid">
+foo.dxDataGrid(PXP.DevExpress.ExtendGridConfiguration({"dataSource":[{"gradeBookId":"9001","GBAssignment":"{\\"value\\":\\"HW 1.1\\"}"},{"gradeBookId":9002,"GBAssignment":"{\\"value\\":\\"Unit 1 Test\\"}"}]}));
+</div>
+`;
+
+test('extracts grading periods from gradebook HTML', () => {
+	const focus = extractGbFocusData(gradebookHtml);
+	expect(focus.GradingPeriods[0]?.Name).toBe('Quarter 1');
+	expect(focus.GradingPeriods[0]?.defaultFocus).toBe(true);
+});
+
+test('extracts focus args, room, and marks for a course', () => {
+	expect(extractFocusArgsForCourse(gradebookHtml, 101)).toEqual({ classID: 101, AGU: 0 });
+	expect(extractCourseChrome(gradebookHtml, 101)).toEqual({
+		room: 'B12',
+		markPreview: 'A',
+		scorePreview: '92.5%'
+	});
+});
+
+test('extracts assignment names from class details HTML', () => {
+	expect(extractAssignmentNames(classDetailsHtml)).toEqual({
+		9001: 'HW 1.1',
+		9002: 'Unit 1 Test'
+	});
+});
+
+test('allowlists only StudentVUE gradebook paths', () => {
+	expect(isAllowedStudentVuePath('/PXP2_GradeBook.aspx?AGU=0')).toBe(true);
+	expect(isAllowedStudentVuePath('/service/PXP2Communication.asmx/LoadControl')).toBe(true);
+	expect(isAllowedStudentVuePath('/Service/PXPCommunication.asmx')).toBe(false);
+	expect(isAllowedStudentVuePath('https://evil.example/PXP2_GradeBook.aspx')).toBe(false);
+});
+
+test('normalizes pasted portal URLs to a hostname', () => {
+	expect(normalizeDomain('https://ca-pleas-psv.edupoint.com/Home_PXP2.aspx')).toBe(
+		'ca-pleas-psv.edupoint.com'
+	);
+	expect(normalizeDomain('ca-pleas-psv.edupoint.com')).toBe('ca-pleas-psv.edupoint.com');
+});


### PR DESCRIPTION
## Summary
- Restores live StudentVUE login without a GradeCompass server by adding a Chrome MV3 companion extension. The site cannot attach the new HttpOnly/SameSite session (issue #221 / D5518-00); the extension requests optional host permission for the district, opens the official portal login, and fetches allowlisted PXP2 JSON endpoints with the browser cookie jar.
- Maps PXP2 gradebook JSON into the existing Gradebook types so hypothetical-grade math and the current UI stay unchanged. Demo/SOAP/MSW path is preserved. Attendance, mail, and documents remain demo-only in this PR.
- Credentials never enter GradeCompass JS. No new runtime packages.

## Test plan
- [ ] bun test
- [ ] bun run extension:build, then load extension/dist unpacked in Chrome
- [ ] bun run dev at http://gradecompass.localhost:5173
- [ ] Without the extension, login stays blocked and demo still works
- [ ] With the extension, enter a v2025 district host, log in on StudentVUE, confirm grades/categories/assignments load
- [ ] Switch report periods and confirm cache refresh
- [ ] Confirm attendance/mail/documents are hidden in live PXP2 mode
